### PR TITLE
Add check IDs and documentation

### DIFF
--- a/CHECKS.md
+++ b/CHECKS.md
@@ -1,0 +1,383 @@
+# Checks
+
+Explanations of all checks in `ezproxy-config-lint`.
+
+| Check           | Short description
+|-----------------|------------------
+| **L1**          | **Ordering Issues**
+| [L1001](#l1001) | `Title` directive is out of order
+| [L1002](#l1002) | `URL` directive is out of order
+| [L1003](#l1003) | `AnonymousURL -*` directive is out of order
+| [L1004](#l1004) | `AnonymousURL` directive is out of order
+| [L1005](#l1005) | `Option Cookie` directive is out of order
+| [L1006](#l1006) | `Option CookiePassThrough` directive is out of order
+| [L1007](#l1007) | `Option DomainCookieOnly` directive is out of order
+| [L1008](#l1008) | `ProxyHostnameEdit` directive is out of order
+| [L1009](#l1009) | `ProxyHostnameEdit` domains should be placed in deepest-to-shallowest order
+| [L1010](#l1010) | `URL` directive is before `Title` directive
+| [L1011](#l1011) | `Option Cookie` directive should not preceed closing AnonymousURL
+| **L2**          | **Duplication Issues**
+| [L2001](#l2001) | Duplicate `Title` directive in stanza
+| [L2002](#l2002) | Origin already seen
+| [L2003](#l2003) | Duplicate `URL` directive in stanza
+| [L2004](#l2004) | `Title` value already seen
+| **L3**          | **Malformation Issues**
+| [L3001](#l3001) | `ProxyHostnameEdit` directive must have two values
+| [L3002](#l3002) | Find part of `ProxyHostnameEdit` directive should end with a `$`
+| [L3003](#l3003) | Replace part of `ProxyHostnameEdit` directive is malformed
+| [L3004](#l3004) | `Domain` and `DomainJavaScript` directives should only specify domains
+| [L3005](#l3005) | Unable to parse `URL`
+| [L3006](#l3006) | `URL` does not start with `http` or `https`
+| [L3007](#l3007) | `URL` is not using HTTPS scheme
+| [L3008](#l3008) | `Option` directive not in the form `Option OPTIONNAME`
+| **L4**          | **Missing Directive Issues**
+| [L4001](#l4001) | Missing `AnonymousURL -*` clearing at end of stanza
+| [L4002](#l4002) | Missing `Option Cookie` at end of stanza
+| [L4003](#l4003) | Stanza has `Title` but no `URL`
+| [L4004](#l4004) | `Find` directive must be immediately proceeded with a `Replace` directive
+| **L5**          | **Styling Issues**
+| [L5001](#l5001) | Directive name improperly styled
+| **L9**          | **Other Issues**
+| [L9001](#l9001) | Unknown directive
+| [L9002](#l9002) | Source title doesn't match
+
+## L1 - Ordering Issues
+
+### L1001
+
+#### `Title` directive is out of order
+
+The `Title` directive are only allowed to follow these directives:
+
+* `AddUserHeader`
+* `Group`
+* `HTTPMethod`
+* `Option CookiePassThrough`
+* `Option DomainCookieOnly`
+* `OptionEbraryUnencodedTokens`
+* `ProxyHostnameEdit`
+* `Referer`
+
+Additionally, a `Title` will be considered out of order when
+[L4001](#l4001) or [L4002](#l4002) are detected.
+
+---------
+
+### L1002
+
+#### `URL` directive is out of order
+
+The `URL` directive are only allowed to follow these directives:
+
+* `AllowVars`
+* `EBLSecret`
+* `EbrarySite`
+* `EncryptVar`
+* `HTTPHeader`
+* `MimeFilter`
+* `Title`
+
+---------
+
+### L1003
+
+#### `AnonymousURL -*` directive is out of order
+
+The `AnonymousURL -*` directive is only allowed to follow these directives:
+
+* `DomainJavaScript`
+* `Domain`
+* `HostJavaScript`
+* `Host`
+* `Replace`
+* `URL`
+
+---------
+
+### L1004
+
+#### `AnonymousURL` directive is out of order
+
+Except for the ending `AnonymousURL -*` usage (see [L1003](#l1003]),
+the `AnonymousURL` directive is only allowed to follow these directives:
+
+* `AnonymousURL`
+* `Group`
+* `HTTPMethod`
+* `OptionCookiePassThrough`
+* `OptionCookie`
+* `OptionDomainCookieOnly`
+* `ProxyHostnameEdit`
+
+---------
+
+### L1005
+
+#### `Option Cookie` directive is out of order
+
+The `Option Cookie` directive is only allowed to follow these directives:
+
+* `Domain`
+* `DomainJavaScript`
+* `Host`
+* `HostJavaScript`
+* `Replace`
+* `URL`
+
+---------
+
+### L1006
+
+#### `Option CookiePassThrough` directive is out of order
+
+The `Option CookiePassThrough` directive is only allowed to follow these
+directives:
+
+* `Group`
+* `HTTPMethod`
+
+---------
+
+### L1007
+
+#### `Option DomainCookieOnly` directive is out of order
+
+The `Option DomainCookieOnly` directive is only allowed to follow these
+directives:
+
+* `Group`
+* `HTTPMethod`
+* `Option X-Forwarded-For`
+
+---------
+
+### L1008
+
+#### `ProxyHostnameEdit` directive is out of order
+
+The `ProxyHostnameEdit` directive is only allowed to follow these directives:
+
+* `Group`
+* `HTTPMethod`
+* `Option Cookie`
+* `Option CookiePassThrough`
+* `Option DomainCookieOnly`
+* `ProxyHostnameEdit`
+
+---------
+
+### L1009
+
+#### `ProxyHostnameEdit` domains should be placed in deepest-to-shallowest order
+
+This is best explained with an example.
+Lets say you have these two lines in your stanza:
+
+```
+ProxyHostnameEdit heinonline.org$ heinonline-org
+ProxyHostnameEdit home.heinonline.org$ home-heinonline-org
+```
+
+Assume EZproxy was processing the domain name `home.heinonline.org`.
+It would start with the first line, and the resulting find and replace action would generate the domain name `home.heinonline-org`.
+Because that domain name has one period and one hyphen, it would not match the second `ProxyHostnameEdit` line.
+You always want to start with more specific, deeper subdomains. 
+
+We use "deeper" instead of "longer" here, because areallylongdomainhere.com is only two components deep,
+but a.short.domain.ca is four components deep.
+
+---------
+
+### L1010
+
+#### `URL` directive is before `Title` directive
+
+The `URL` directive should always come after the `Title` is a given stanza.
+
+---------
+
+### L1011
+
+#### `Option Cookie` directive should not preceed closing AnonymousURL
+
+The `Option Cookie` directive should come after the final `AnonymousURL -*`
+directive, not before.
+
+
+## L2 - Duplication Issues
+
+### L2001
+
+#### Duplicate `Title` directive in stanza
+
+More than one `Title` directive present in a stanza.
+
+---------
+
+### L2002
+
+#### Origin already seen
+
+EZproxy [only reads origins and does not read paths](https://help.oclc.org/Library_Management/EZproxy/Configure_resources/Groups).
+The origin is the combination of the scheme (http or https), the host (google.com, help.oclc.org), and the port.
+EZproxy does not care about paths (/astronomy, /login).
+The linter will report if you've already used an origin, so that you can ensure that limiting access via Groups works as you expect.
+
+---------
+
+### L2003
+
+#### Duplicate `URL` directive in stanza
+
+More than one `URL` directive present in a stanza.
+
+---------
+
+### L2004
+
+#### `Title` value already seen
+
+The linter tracks stanza `Title` values and reports when a value has been seen more than
+once.
+
+
+## L3 - Malformation Issues
+
+### L3001
+
+#### `ProxyHostnameEdit` directive must have two values
+
+The `ProxyHostnameEdit` directive requires two parameters.
+See [OCLC Documentation](https://help.oclc.org/Library_Management/EZproxy/Configure_resources/ProxyHostnameEdit) for more details.
+
+---------
+
+### L3002
+
+#### Find part of `ProxyHostnameEdit` directive should end with a `$`
+
+The first (*find*) parameter to `ProxyHostnameEdit` is a regular expression
+and should end in a dollar sign (`$`) to match the end of the string.
+
+---------
+
+### L3003
+
+#### Replace part of `ProxyHostnameEdit` directive is malformed
+
+FIXME
+
+---------
+
+### L3004
+
+#### `Domain` and `DomainJavaScript` directives should only specify domains
+
+The `Domain` and `DomainJavaScript` directives should only specify domains.
+No URLs or path components should be used.
+
+---------
+
+### L3005
+
+#### Unable to parse `URL`
+
+The `URL` directive.  Ensure line is not malformed.
+
+---------
+
+### L3006
+
+#### `URL` does not start with `http` or `https`
+
+FIXME
+
+---------
+
+### L3007
+
+#### `URL` is not using HTTPS scheme
+
+The scheme of the *url* in the `URL` directive is not using HTTPS.
+
+---------
+
+### L3008
+
+#### `Option` directive not in the form `Option OPTIONNAME`
+
+The `Option` directive requires one and only one parameter.
+
+
+## L4 - Missing Directive Issues
+
+### L4001
+
+#### Missing `AnonymousURL -*` clearing at end of stanza
+
+---------
+
+### L4002
+
+#### Missing `Option Cookie` at end of stanza
+
+---------
+
+### L4003
+
+#### Stanza has `Title` but no `URL`
+
+---------
+
+### L4004
+
+#### `Find` directive must be immediately proceeded with a `Replace` directive
+
+
+## L5 - Styling Issues
+
+### L5001
+
+#### Directive name improperly styled
+
+FIXME - See Issue #23
+
+---------
+
+
+## L9 - Other Issues
+
+### L9001
+
+#### Unknown directive
+
+An unknown directive was encountered.  Linter directive checks are
+case-sensitive.  Ensure that letter casing is correct.
+
+---------
+
+### L9002
+
+#### Source title doesn't match
+
+The linter has a built-in way to check the OCLC website for updates to some database stanzas.
+If a comment is seen which matches the pattern `# Source - https://help.oclc.org/Library_Management/EZproxy/EZproxy_database_stanzas/...`,
+the tool will check the stanza at the provided URL and pull out the `Title` directive.
+The tool will report if the stanza title in the config file does not match the stanza title from the OCLC website.
+
+For example, for the resource Docuseek2, if the stanza begins with a `Source` comment:
+
+```
+# Source - https://help.oclc.org/Library_Management/EZproxy/EZproxy_database_stanzas/Database_stanzas_D/Docuseek2
+Title Docuseek2 (updated 20180101)
+...
+```
+the linter will visit https://help.oclc.org/Library_Management/EZproxy/EZproxy_database_stanzas/Database_stanzas_D/Docuseek2,
+and pull out the `Title` directive, which might be:
+
+```
+Title Docuseek2 (updated 20191015)
+...
+```
+
+Because the `Title` directives do not match, the tool will report that you might want to update the stanza from the source.

--- a/main.go
+++ b/main.go
@@ -251,15 +251,15 @@ func (l *Linter) ProcessLineAt(line, at string) (m []string) {
 	// Is the line empty, or an empty comment?
 	if line == "" || line == "#" {
 		if l.State.Title != "" && l.State.URL == "" {
-			m = append(m, fmt.Sprintf("Stanza \"%v\" has Title but no URL", l.State.Title))
+			m = append(m, fmt.Sprintf("Stanza \"%v\" has Title but no URL (L4003)", l.State.Title))
 		}
 		if l.State.AnonymousURLNeedsClosing {
-			m = append(m, fmt.Sprintf("Stanza \"%v\" has AnonymousURL but doesn't have a corresponding \"AnonymousURL -*\" "+
+			m = append(m, fmt.Sprintf("Stanza \"%v\" has AnonymousURL but doesn't have a corresponding \"AnonymousURL -*\" (L4001)"+
 				"line at the end of the stanza", l.State.Title))
 		}
 		if l.State.CookieOptionNeedsClosing {
 			m = append(m, fmt.Sprintf("Stanza \"%v\" has \"Option DomainCookieOnly\" or \"Option CookiePassthrough\" "+
-				"but doesn't have a corresponding \"Option Cookie\" line at the end of the stanza", l.State.Title))
+				"but doesn't have a corresponding \"Option Cookie\" line at the end of the stanza (L4002)", l.State.Title))
 		}
 		// Reset the stanza state.
 		l.State = State{LastLineEmpty: true}
@@ -301,7 +301,7 @@ func (l *Linter) ProcessLineAt(line, at string) (m []string) {
 	// Option directives have two parts.
 	if label == "Option" {
 		if len(split) != 2 {
-			m = append(m, "Option directive not in the form Option OPTIONNAME")
+			m = append(m, "Option directive not in the form Option OPTIONNAME (L3008)")
 			return m
 		}
 		label = line
@@ -310,13 +310,13 @@ func (l *Linter) ProcessLineAt(line, at string) (m []string) {
 	// Find the Directive which matches this label.
 	directive, ok := LabelToDirective[label]
 	if !ok {
-		m = append(m, "Unknown directive")
+		m = append(m, "Unknown directive (L9001)")
 		return m
 	}
 
 	// Short-circuit check for Find/Replace pairs.
 	if l.State.Previous == Find && directive != Replace {
-		m = append(m, "Find directive must be immediately proceeded with a Replace directive.")
+		m = append(m, "Find directive must be immediately proceeded with a Replace directive (L4004)")
 	}
 
 	// Check each directive.
@@ -328,17 +328,17 @@ func (l *Linter) ProcessLineAt(line, at string) (m []string) {
 				// OptionCookie is allowed after these directives.
 			case AnonymousURL:
 				if l.State.AnonymousURLNeedsClosing {
-					m = append(m, "Option Cookie directive is out of order")
+					m = append(m, "Option Cookie directive is out of order, should not preceed closing AnonymousURL (L1011)")
 				}
 			default:
-				m = append(m, "Option Cookie directive is out of order")
+				m = append(m, "Option Cookie directive is out of order (L1005)")
 			}
 			l.State.CookieOptionNeedsClosing = false
 		} else {
 			switch l.State.Previous {
 			case Undefined, HTTPMethod:
 			default:
-				m = append(m, "Option Cookie directive is out of order")
+				m = append(m, "Option Cookie directive is out of order (L1005)")
 			}
 		}
 	case OptionCookiePassThrough:
@@ -346,7 +346,7 @@ func (l *Linter) ProcessLineAt(line, at string) (m []string) {
 		case Undefined, Group, HTTPMethod:
 			// OptionCookiePassThrough is allowed after these directives.
 		default:
-			m = append(m, "Option CookiePassThrough directive is out of order")
+			m = append(m, "Option CookiePassThrough directive is out of order (L1006)")
 		}
 		l.State.CookieOptionNeedsClosing = true
 	case OptionDomainCookieOnly:
@@ -354,7 +354,7 @@ func (l *Linter) ProcessLineAt(line, at string) (m []string) {
 		case Undefined, Group, HTTPMethod, OptionXForwardedFor:
 			// OptionDomainCookieOnly is allowed after these directives.
 		default:
-			m = append(m, "Option DomainCookieOnly directive is out of order")
+			m = append(m, "Option DomainCookieOnly directive is out of order (L1007)")
 		}
 		l.State.CookieOptionNeedsClosing = true
 	case ProxyHostnameEdit:
@@ -364,23 +364,23 @@ func (l *Linter) ProcessLineAt(line, at string) (m []string) {
 			ProxyHostnameEdit:
 			// ProxyHostnameEdit is allowed after these directives.
 		default:
-			m = append(m, "ProxyHostnameEdit directive is out of order")
+			m = append(m, "ProxyHostnameEdit directive is out of order (L1008)")
 		}
 		hostnameEditPair := strings.Split(TrimDirective(line, directive), " ")
 		if len(hostnameEditPair) != 2 {
-			m = append(m, "ProxyHostnameEdit directive must have two values")
+			m = append(m, "ProxyHostnameEdit directive must have two values (L3001)")
 			break
 		}
 		find, found := strings.CutSuffix(hostnameEditPair[0], "$")
 		if !found {
-			m = append(m, "Find part of ProxyHostnameEdit directive should end with a $")
+			m = append(m, "Find part of ProxyHostnameEdit directive should end with a $ (L3002)")
 		}
 		if strings.ReplaceAll(find, ".", "-") != hostnameEditPair[1] {
-			m = append(m, "Replace part of ProxyHostnameEdit directive is malformed")
+			m = append(m, "Replace part of ProxyHostnameEdit directive is malformed (L3003)")
 		}
 		depth := strings.Count(find, ".") + 1
 		if l.State.ProxyHostnameEditDepth != 0 && l.State.ProxyHostnameEditDepth < depth {
-			m = append(m, "ProxyHostnameEdit domains should be placed in deepest-to-shallowest order")
+			m = append(m, "ProxyHostnameEdit domains should be placed in deepest-to-shallowest order (L1009)")
 		}
 		l.State.ProxyHostnameEditDepth = depth
 	case AnonymousURL:
@@ -389,14 +389,14 @@ func (l *Linter) ProcessLineAt(line, at string) (m []string) {
 			case URL, Host, HostJavaScript, Domain, DomainJavaScript, Replace:
 				// AnonymousURL is allowed after these directives.
 			default:
-				m = append(m, "AnonymousURL directive is out of order")
+				m = append(m, "Final AnonymousURL directive is out of order (L1003)")
 			}
 			l.State.AnonymousURLNeedsClosing = false
 		} else {
 			switch l.State.Previous {
 			case Undefined, Group, HTTPMethod, OptionCookie, OptionCookiePassThrough, OptionDomainCookieOnly, ProxyHostnameEdit, AnonymousURL:
 			default:
-				m = append(m, "AnonymousURL directive is out of order")
+				m = append(m, "AnonymousURL directive is out of order (L1004)")
 			}
 			l.State.AnonymousURLNeedsClosing = true
 		}
@@ -408,33 +408,33 @@ func (l *Linter) ProcessLineAt(line, at string) (m []string) {
 			// Title is allowed after these directives.
 		case OptionCookie:
 			if !l.State.CookieOptionNeedsClosing {
-				m = append(m, "Title directive is out of order")
+				m = append(m, fmt.Sprintf("Title directive is out of order, previous token: %v (L1001)", l.State.Previous))
 			}
 		case AnonymousURL:
 			if !l.State.AnonymousURLNeedsClosing {
-				m = append(m, "Title directive is out of order")
+				m = append(m, fmt.Sprintf("Title directive is out of order, previous token: %v (L1001)", l.State.Previous))
 			}
 		default:
-			m = append(m, "Title directive is out of order")
+			m = append(m, fmt.Sprintf("Title directive is out of order, previous token: %v (L1001)", l.State.Previous))
 		}
 		if l.State.Title != "" {
-			m = append(m, "Duplicate Title directive")
+			m = append(m, "Duplicate Title directive in stanza (L2001)")
 		}
 		l.State.Title = TrimDirective(line, directive)
 		titleSeenAt, titleSeen := l.PreviousTitles[l.State.Title]
 		if titleSeen {
-			m = append(m, fmt.Sprintf("Title already seen at %v", titleSeenAt))
+			m = append(m, fmt.Sprintf("Title value already seen at %v (L2004)", titleSeenAt))
 		} else {
 			l.PreviousTitles[l.State.Title] = at
 		}
 		if l.State.OCLCTitle != "" && l.State.Title != l.State.OCLCTitle {
-			m = append(m, "Source title doesn't match, you might need to update this stanza.")
+			m = append(m, "Source title doesn't match, you might need to update this stanza (L9002)")
 		}
 	case Host, HostJavaScript:
 		trimmed := TrimDirective(line, directive)
 		parsedURL, err := url.Parse(trimmed)
 		if err != nil {
-			m = append(m, fmt.Sprintf("Unable to parse URL, might be malformed: %v", err))
+			m = append(m, fmt.Sprintf("Unable to parse URL, might be malformed: %v (L3005)", err))
 			break
 		}
 		if parsedURL.Host == "" {
@@ -442,51 +442,51 @@ func (l *Linter) ProcessLineAt(line, at string) (m []string) {
 			// Per the EZproxy docs, http:// is assumed.
 			parsedURL, err = url.Parse("http://" + trimmed)
 			if err != nil {
-				m = append(m, fmt.Sprintf("Unable to parse URL, might be malformed: %v", err))
+				m = append(m, fmt.Sprintf("Unable to parse URL, might be malformed: %v (L3005)", err))
 				break
 			}
 		}
 		origin := fmt.Sprintf("%v://%v", parsedURL.Scheme, parsedURL.Host)
 		originSeenAt, originSeen := l.PreviousOrigins[origin]
 		if originSeen {
-			m = append(m, fmt.Sprintf("Origin already seen at %v", originSeenAt))
+			m = append(m, fmt.Sprintf("Origin already seen at %v (L2002)", originSeenAt))
 		} else {
 			l.PreviousOrigins[origin] = at
 		}
 	case Domain, DomainJavaScript:
 		parsedURL, err := url.Parse(TrimDirective(line, directive))
 		if err != nil {
-			m = append(m, fmt.Sprintf("Unable to parse URL, might be malformed: %v", err))
+			m = append(m, fmt.Sprintf("Unable to parse URL, might be malformed: %v (L3005)", err))
 			break
 		}
 		if parsedURL.Scheme != "" || strings.Contains(parsedURL.Path, "/") {
-			m = append(m, "Domain and DomainJavaScript directives should only specify domains")
+			m = append(m, "Domain and DomainJavaScript directives should only specify domains (L3004)")
 		}
 	case URL:
 		switch l.State.Previous {
 		case Title, HTTPHeader, MimeFilter, AllowVars, EncryptVar, EBLSecret, EbrarySite:
 			// URL is allowed after these directives.
 		default:
-			m = append(m, "URL directive is out of order")
+			m = append(m, "URL directive is out of order (L1002)")
 		}
 		if l.State.Title == "" {
-			m = append(m, "URL directive is before Title directive")
+			m = append(m, "URL directive is before Title directive (L1010)")
 		}
 		if l.State.URL != "" {
-			m = append(m, "Duplicate URL directive")
+			m = append(m, "Duplicate URL directive in stanza (L2003)")
 		}
 		l.State.URL = TrimDirective(line, directive)
 		parsedURL, err := url.Parse(l.State.URL)
 		if err != nil {
-			m = append(m, fmt.Sprintf("Unable to parse URL, might be malformed: %v", err))
+			m = append(m, fmt.Sprintf("Unable to parse URL, might be malformed: %v (L3005)", err))
 			break
 		}
 		if parsedURL.Host == "" {
-			m = append(m, "URL does not start with http or https")
+			m = append(m, "URL does not start with http or https (L3006)")
 			break
 		}
 		if l.HTTPS && parsedURL.Scheme != "https" {
-			m = append(m, "URL is not using HTTPS scheme")
+			m = append(m, "URL is not using HTTPS scheme (L3007)")
 		}
 		// According to the EZproxy docs, 'Starting point URLs and config.txt',
 		// URL, Host, and HostJavaScript directives are checked for starting point URLs.

--- a/main_test.go
+++ b/main_test.go
@@ -23,7 +23,7 @@ func TestMissingURL(t *testing.T) {
 	linter := Linter{State: State{
 		Title: "A Title",
 	}}
-	expected := []string{"Stanza \"A Title\" has Title but no URL"}
+	expected := []string{"Stanza \"A Title\" has Title but no URL (L4003)"}
 	messages := linter.ProcessLineAt("", "test:1")
 	if !reflect.DeepEqual(messages, expected) {
 		t.Fatalf("incorrect messages %v instead of %v", messages, expected)
@@ -35,7 +35,7 @@ func TestMalformedURL(t *testing.T) {
 		Title:    "A Title",
 		Previous: Title,
 	}}
-	expected := []string{"Unable to parse URL, might be malformed: parse \"http://[boo\": missing ']' in host"}
+	expected := []string{"Unable to parse URL, might be malformed: parse \"http://[boo\": missing ']' in host (L3005)"}
 	messages := linter.ProcessLineAt("URL http://[boo", "test:1")
 	if !reflect.DeepEqual(messages, expected) {
 		t.Fatalf("incorrect messages %v instead of %v", messages, expected)
@@ -47,7 +47,7 @@ func TestURLWithoutScheme(t *testing.T) {
 		Title:    "A Title",
 		Previous: Title,
 	}}
-	expected := []string{"URL does not start with http or https"}
+	expected := []string{"URL does not start with http or https (L3006)"}
 	messages := linter.ProcessLineAt("URL google.com", "test:1")
 	if !reflect.DeepEqual(messages, expected) {
 		t.Fatalf("incorrect messages %v instead of %v", messages, expected)
@@ -56,7 +56,7 @@ func TestURLWithoutScheme(t *testing.T) {
 
 func TestMalformedHost(t *testing.T) {
 	linter := Linter{}
-	expected := []string{"Unable to parse URL, might be malformed: parse \"http://[]w]w[ef\": invalid port \"w[ef\" after host"}
+	expected := []string{"Unable to parse URL, might be malformed: parse \"http://[]w]w[ef\": invalid port \"w[ef\" after host (L3005)"}
 	messages := linter.ProcessLineAt("HJ []w]w[ef", "test:1")
 	if !reflect.DeepEqual(messages, expected) {
 		t.Fatalf("incorrect messages %v instead of %v", messages, expected)
@@ -107,7 +107,7 @@ func TestFindReplacePair(t *testing.T) {
 	linter := Linter{State: State{
 		Previous: Find,
 	}}
-	expected := []string{"Find directive must be immediately proceeded with a Replace directive."}
+	expected := []string{"Find directive must be immediately proceeded with a Replace directive (L4004)"}
 	messages := linter.ProcessLineAt("NeverProxy google.com", "test:1")
 	if !reflect.DeepEqual(messages, expected) {
 		t.Fatalf("incorrect messages %v instead of %v", messages, expected)


### PR DESCRIPTION
I was cleaning up some cruft in our EZproxy config and got annoyed at not knowing what the linter was wanting.  One thing led to another, and I started categorizing checks into groups, giving them ID numbers, and documenting the logic.

I didn't spend a ton of time on the taxonomy, but it seems okay to me.  Feel free to suggest improvements or submit changes to my branch.

Some notes on a few checks:

* L3003 - Unclear to me what this check is enforcing.
* L3006 - Unclear to me what this check is checking.
* L5001 - can be removed if #23 is delayed or shot down.
* L9001 - description would be updated if #23 is resolved.

Thanks for looking.