### PR TITLE
Add support for detecting misstyled directives

### DIFF
--- a/main.go
+++ b/main.go
@@ -310,7 +310,24 @@ func (l *Linter) ProcessLineAt(line, at string) (m []string) {
 	// Find the Directive which matches this label.
 	directive, ok := LabelToDirective[label]
 	if !ok {
-		m = append(m, "Unknown directive")
+		// If no directive is matched, do a case-insensitive search
+		// of all directives to see if we have a misstyled directive.
+		tLabel := strings.ToUpper(label)
+		misstyledDirective := false
+		for k := range LabelToDirective {
+			if strings.ToUpper(k) == tLabel {
+				misstyledDirective = true
+				// reuse tLabel to store the correct directive
+				tLabel = k
+				break
+			}
+		}
+
+		if misstyledDirective {
+			m = append(m, fmt.Sprintf("%v directive improperly styled as %v", tLabel, label))
+		} else {
+			m = append(m, fmt.Sprintf("Unknown directive %v", label))
+		}
 		return m
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -113,3 +113,21 @@ func TestFindReplacePair(t *testing.T) {
 		t.Fatalf("incorrect messages %v instead of %v", messages, expected)
 	}
 }
+
+func TestMisstyledDirective(t *testing.T) {
+	linter := Linter{State: State{}}
+	expected := []string{"Title directive improperly styled as TITLE"}
+	messages := linter.ProcessLineAt("TITLE Foo", "test:1")
+	if !reflect.DeepEqual(messages, expected) {
+		t.Fatalf("incorrect messages %v instead of %v", messages, expected)
+	}
+}
+
+func TestUnknownDirective(t *testing.T) {
+	linter := Linter{State: State{}}
+	expected := []string{"Unknown directive FooBar"}
+	messages := linter.ProcessLineAt("FooBar Baz", "test:1")
+	if !reflect.DeepEqual(messages, expected) {
+		t.Fatalf("incorrect messages %v instead of %v", messages, expected)
+	}
+}


### PR DESCRIPTION
When an unknown directive is found, do a case-insensitive search of all directives to see if we have a misstyled directive.

Also add additional context to unknown directive output.

Fixes #23