### PR TITLE
Rework some Option directives, add quotes in output

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -36,6 +36,8 @@ archives:
       - goos: windows
         format: zip
     wrap_in_directory: true
+    files:
+      - "*.md"
 
 changelog:
   sort: asc

--- a/CHECKS.md
+++ b/CHECKS.md
@@ -2,45 +2,46 @@
 
 Explanations of all checks in `ezproxy-config-lint`.
 
-| Check           | Short description
-|-----------------|------------------
-| **L1**          | **Ordering Issues**
-| [L1001](#l1001) | `Title` directive is out of order
-| [L1002](#l1002) | `URL` directive is out of order
-| [L1003](#l1003) | `AnonymousURL -*` directive is out of order
-| [L1004](#l1004) | `AnonymousURL` directive is out of order
-| [L1005](#l1005) | An Option 'opener' directive is out of order
-| [L1006](#l1006) | An Option 'closer' directive is out of order
-| [L1008](#l1008) | `ProxyHostnameEdit` directive is out of order
-| [L1009](#l1009) | `ProxyHostnameEdit` domains should be placed in deepest-to-shallowest order
-| [L1010](#l1010) | `URL` directive is before `Title` directive
-| **L2**          | **Duplication Issues**
-| [L2001](#l2001) | Duplicate `Title` directive in stanza
-| [L2002](#l2002) | Origin already seen
-| [L2003](#l2003) | Duplicate `URL` directive in stanza
-| [L2004](#l2004) | `Title` value already seen
-| **L3**          | **Malformation Issues**
-| [L3001](#l3001) | `ProxyHostnameEdit` directive must have both a find and replace qualifier
-| [L3002](#l3002) | Find part of `ProxyHostnameEdit` directive should end with a `$`
-| [L3003](#l3003) | Replace part of `ProxyHostnameEdit` directive is malformed
-| [L3004](#l3004) | `Domain` and `DomainJavaScript` directives should only specify domains
-| [L3005](#l3005) | Unable to parse `URL`
-| [L3006](#l3006) | `URL` does not start with `http` or `https`
-| [L3007](#l3007) | `URL` is not using HTTPS scheme
-| [L3008](#l3008) | `Option` directive not in the form `Option OPTIONNAME`
-| [L3009](#l3009) | `URL` directive is not in the right format
-| **L4**          | **Missing Directive Issues**
-| [L4001](#l4001) | Missing `AnonymousURL -*` clearing at end of stanza
-| [L4002](#l4002) | Missing Option at end of stanza
-| [L4003](#l4003) | Stanza has `Title` but no `URL`
-| [L4004](#l4004) | `Find` directive must be immediately proceeded with a `Replace` directive
-| **L5**          | **Styling Issues**
-| [L5001](#l5001) | Directive uses the wrong case.
-| [L5002](#l5002) | Line ends in a space or tab character.
-| **L9**          | **Other Issues**
-| [L9001](#l9001) | Unknown directive
-| [L9002](#l9002) | Source title doesn't match
-| [L9003](#l9003) | Error processing Source line
+<!-- ToC begin -->
+  - [L1 - Ordering Issues](#l1---ordering-issues)
+    - [L1001 - `Title` directive is out of order](#l1001---title-directive-is-out-of-order)
+    - [L1002 - `URL` directive is out of order](#l1002---url-directive-is-out-of-order)
+    - [L1003 - `AnonymousURL -*` directive is out of order](#l1003---anonymousurl---directive-is-out-of-order)
+    - [L1004 - `AnonymousURL` directive is out of order](#l1004---anonymousurl-directive-is-out-of-order)
+    - [L1005 - An Option 'opener' directive is out of order](#l1005---an-option-opener-directive-is-out-of-order)
+    - [L1006 - An Option 'closer' directive is out of order](#l1006---an-option-closer-directive-is-out-of-order)
+    - [L1008 - `ProxyHostnameEdit` directive is out of order](#l1008---proxyhostnameedit-directive-is-out-of-order)
+    - [L1009 - `ProxyHostnameEdit` domains should be placed in deepest-to-shallowest order](#l1009---proxyhostnameedit-domains-should-be-placed-in-deepest-to-shallowest-order)
+    - [L1010 - `URL` directive is before `Title` directive](#l1010---url-directive-is-before-title-directive)
+  - [L2 - Duplication Issues](#l2---duplication-issues)
+    - [L2001 - Duplicate `Title` directive in stanza](#l2001---duplicate-title-directive-in-stanza)
+    - [L2002 - Origin already seen](#l2002---origin-already-seen)
+    - [L2003 - Duplicate `URL` directive in stanza](#l2003---duplicate-url-directive-in-stanza)
+    - [L2004 - `Title` value already seen](#l2004---title-value-already-seen)
+  - [L3 - Malformation Issues](#l3---malformation-issues)
+    - [L3001 - `ProxyHostnameEdit` directive must have both a find and replace qualifier](#l3001---proxyhostnameedit-directive-must-have-both-a-find-and-replace-qualifier)
+    - [L3002 - Find part of `ProxyHostnameEdit` directive should end with a `$`](#l3002---find-part-of-proxyhostnameedit-directive-should-end-with-a-)
+    - [L3003 - Replace part of `ProxyHostnameEdit` directive is malformed](#l3003---replace-part-of-proxyhostnameedit-directive-is-malformed)
+    - [L3004 -  `Domain` and `DomainJavaScript` directives should only specify domains](#l3004----domain-and-domainjavascript-directives-should-only-specify-domains)
+    - [L3005 - Unable to parse `URL`](#l3005---unable-to-parse-url)
+    - [L3006 - `URL` does not start with `http` or `https`](#l3006---url-does-not-start-with-http-or-https)
+    - [L3007 -  `URL` is not using HTTPS scheme](#l3007----url-is-not-using-https-scheme)
+    - [L3008 - `Option` directive not in the form `Option OPTIONNAME`](#l3008---option-directive-not-in-the-form-option-optionname)
+    - [L3009 - `URL` directive is not in the right format](#l3009---url-directive-is-not-in-the-right-format)
+  - [L4 - Missing Directive Issues](#l4---missing-directive-issues)
+    - [L4001 - Missing `AnonymousURL -*` at end of stanza](#l4001---missing-anonymousurl---at-end-of-stanza)
+    - [L4002 - Missing Option at end of stanza](#l4002---missing-option-at-end-of-stanza)
+    - [L4003 - Stanza has `Title` but no `URL`](#l4003---stanza-has-title-but-no-url)
+    - [L4004 - `Find` directive must be immediately proceeded with a `Replace` directive](#l4004---find-directive-must-be-immediately-proceeded-with-a-replace-directive)
+  - [L5 - Styling Issues](#l5---styling-issues)
+    - [L5001 - Directive uses the wrong case.](#l5001---directive-uses-the-wrong-case)
+    - [L5002 - Line ends in a space or tab character.](#l5002---line-ends-in-a-space-or-tab-character)
+  - [L9 - Other Issues](#l9---other-issues)
+    - [L9001 - Unknown directive](#l9001---unknown-directive)
+    - [L9002 - Source title doesn't match](#l9002---source-title-doesnt-match)
+    - [L9003 - Error processing Source line](#l9003---error-processing-source-line)
+<!-- Generated by gh-toc, https://moonbase59.github.io/gh-toc/ -->
+<!-- ToC end -->
 
 ## L1 - Ordering Issues
 
@@ -309,7 +310,6 @@ The `Option` directive needs a second part. You can see the list of options in t
 
 The `URL` directive must be in the [URL (version 1)](https://help.oclc.org/Library_Management/EZproxy/Configure_resources/URL_version_1), [URL (version 2)](https://help.oclc.org/Library_Management/EZproxy/Configure_resources/URL_version_2), or [URL (version 3)](https://help.oclc.org/Library_Management/EZproxy/Configure_resources/URL_version_3) format. Ensure line is not malformed.
 
-
 ## L4 - Missing Directive Issues
 
 ### L4001 - Missing `AnonymousURL -*` at end of stanza
@@ -365,9 +365,6 @@ The directive was found, but it does not use the normal case. For example, TITLE
 This check is enabled with the `-whitespace=true` option.
 
 Trailing whitespace characters space or tab were found on this line.
-
----------
-
 
 ## L9 - Other Issues
 

--- a/CHECKS.md
+++ b/CHECKS.md
@@ -9,20 +9,18 @@ Explanations of all checks in `ezproxy-config-lint`.
 | [L1002](#l1002) | `URL` directive is out of order
 | [L1003](#l1003) | `AnonymousURL -*` directive is out of order
 | [L1004](#l1004) | `AnonymousURL` directive is out of order
-| [L1005](#l1005) | `Option Cookie` directive is out of order
-| [L1006](#l1006) | `Option CookiePassThrough` directive is out of order
-| [L1007](#l1007) | `Option DomainCookieOnly` directive is out of order
+| [L1005](#l1005) | An Option 'opener' directive is out of order
+| [L1006](#l1006) | An Option 'closer' directive is out of order
 | [L1008](#l1008) | `ProxyHostnameEdit` directive is out of order
 | [L1009](#l1009) | `ProxyHostnameEdit` domains should be placed in deepest-to-shallowest order
 | [L1010](#l1010) | `URL` directive is before `Title` directive
-| [L1011](#l1011) | `Option Cookie` directive should not preceed closing AnonymousURL
 | **L2**          | **Duplication Issues**
 | [L2001](#l2001) | Duplicate `Title` directive in stanza
 | [L2002](#l2002) | Origin already seen
 | [L2003](#l2003) | Duplicate `URL` directive in stanza
 | [L2004](#l2004) | `Title` value already seen
 | **L3**          | **Malformation Issues**
-| [L3001](#l3001) | `ProxyHostnameEdit` directive must have two values
+| [L3001](#l3001) | `ProxyHostnameEdit` directive must have both a find and replace qualifier
 | [L3002](#l3002) | Find part of `ProxyHostnameEdit` directive should end with a `$`
 | [L3003](#l3003) | Replace part of `ProxyHostnameEdit` directive is malformed
 | [L3004](#l3004) | `Domain` and `DomainJavaScript` directives should only specify domains
@@ -33,7 +31,7 @@ Explanations of all checks in `ezproxy-config-lint`.
 | [L3009](#l3009) | `URL` directive is not in the right format
 | **L4**          | **Missing Directive Issues**
 | [L4001](#l4001) | Missing `AnonymousURL -*` clearing at end of stanza
-| [L4002](#l4002) | Missing `Option Cookie` at end of stanza
+| [L4002](#l4002) | Missing Option at end of stanza
 | [L4003](#l4003) | Stanza has `Title` but no `URL`
 | [L4004](#l4004) | `Find` directive must be immediately proceeded with a `Replace` directive
 | **L5**          | **Styling Issues**
@@ -46,37 +44,37 @@ Explanations of all checks in `ezproxy-config-lint`.
 
 ## L1 - Ordering Issues
 
-### L1001
-
-#### `Title` directive is out of order
+### L1001 - `Title` directive is out of order
 
 The `Title` directive are only allowed to follow these directives:
 
-* `AddUserHeader`
 * `Group`
 * `HTTPMethod`
-* `Option CookiePassThrough`
-* `Option DomainCookieOnly`
-* `Option X-Forwarded-For`
-* `Cookie`
-* `Option ebraryUnencodedTokens`
+* `AnonymousURL`
 * `ProxyHostnameEdit`
 * `Referer`
-
-Additionally, a `Title` will be considered out of order when
-[L4001](#l4001) or [L4002](#l4002) are detected.
+* `Cookie`
+* `AddUserHeader`
+* `OptionEbraryUnencodedTokens`
+* `Option DomainCookieOnly`
+* `Option NoCookie`
+* `Option CookiePassThrough`
+* `Option HideEZproxy`
+* `Option NoHttpsHyphens`
+* `Option MetaEZproxyRewriting`
+* `Option ProxyFTP`
+* `Option UTF16`
+* `Option X-Forwarded-For`
 
 ---------
 
-### L1002
-
-#### `URL` directive is out of order
+### L1002 - `URL` directive is out of order
 
 The `URL` directive are only allowed to follow these directives:
 
 * `AllowVars`
 * `EBLSecret`
-* `EbrarySite`
+* `EbrarySit`
 * `EncryptVar`
 * `HTTPHeader`
 * `MimeFilter`
@@ -84,104 +82,118 @@ The `URL` directive are only allowed to follow these directives:
 
 ---------
 
-### L1003
-
-#### `AnonymousURL -*` directive is out of order
+### L1003 - `AnonymousURL -*` directive is out of order
 
 The `AnonymousURL -*` directive is only allowed to follow these directives:
 
-* `DomainJavaScript`
-* `Domain`
-* `HostJavaScript`
-* `Host`
-* `Replace`
 * `URL`
+* `Host`
+* `HostJavaScript`
+* `Domain`
+* `DomainJavaScript`
+* `Replace`
+* `AnonymousURL`
 * `NeverProxy`
+* `ProxyHostnameEdit`
 * `Option Cookie`
-* `Option NoX-Forwarded-For`
+* `Option NoHideEZproxy`
+* `Option HttpsHyphens`
+* `Option NoMetaEZproxyRewriting`
+* `Option NoProxyFTP`
+* `Option NoUTF16`
+* `Option NoXForwardedFor`
 
 ---------
 
-### L1004
+### L1004 - `AnonymousURL` directive is out of order
 
-#### `AnonymousURL` directive is out of order
-
-Except for the ending `AnonymousURL -*` usage (see [L1003](#l1003]),
+Except for the ending `AnonymousURL -*` usage (see [L1003](#l1003])),
 the `AnonymousURL` directive is only allowed to follow these directives:
 
-* `AnonymousURL`
 * `Group`
 * `HTTPMethod`
-* `Option CookiePassThrough`
-* `Option Cookie`
-* `Option DomainCookieOnly`
-* `Option X-Forwarded-For`
-* `ProxyHostnameEdit`
-
----------
-
-### L1005
-
-#### `Option Cookie` directive is out of order
-
-The `Option Cookie` directive is only allowed to follow these directives at the beginning of the stanza:
-
-* `Group`
-* `HTTPMethod`
-* `Option X-Forwarded-For`
-* `AnonymousURL`
-
-The directive should also be used at the end of the stanza to ensure other cookie handling options do not impact other stanzas.
-
----------
-
-### L1006
-
-#### `Option CookiePassThrough` directive is out of order
-
-The `Option CookiePassThrough` directive is only allowed to follow these directives:
-
-* `Group`
-* `HTTPMethod`
-* `Option X-Forwarded-For`
-* `AnonymousURL`
-
----------
-
-### L1007
-
-#### `Option DomainCookieOnly` directive is out of order
-
-The `Option DomainCookieOnly` directive is only allowed to follow these
-directives:
-
-* `Group`
-* `HTTPMethod`
-* `Option X-Forwarded-For`
-* `AnonymousURL`
-
----------
-
-### L1008
-
-#### `ProxyHostnameEdit` directive is out of order
-
-The `ProxyHostnameEdit` directive is only allowed to follow these directives:
-
-* `Group`
-* `HTTPMethod`
-* `Option Cookie`
-* `Option CookiePassThrough`
-* `Option DomainCookieOnly`
-* `Option X-Forwarded-For`
 * `AnonymousURL`
 * `ProxyHostnameEdit`
+* `Option DomainCookieOnly`
+* `Option NoCookie`
+* `Option CookiePassThrough`
+* `Option HideEZproxy`
+* `Option NoHttpsHyphens`
+* `Option MetaEZproxyRewriting`
+* `Option ProxyFTP`
+* `Option UTF16`
+* `Option X-Forwarded-For`
 
 ---------
 
-### L1009
+### L1005 - An Option 'opener' directive is out of order
 
-#### `ProxyHostnameEdit` domains should be placed in deepest-to-shallowest order
+* `Option DomainCookieOnly`
+* `Option NoCookie`
+* `Option CookiePassThrough`
+* `Option HideEZproxy`
+* `Option NoHttpsHyphens`
+* `Option MetaEZproxyRewriting`
+* `Option ProxyFTP`
+* `Option UTF16`
+* `Option X-Forwarded-For`
+
+directives are only allowed to follow other 'opener' directives and:
+
+* `Group`
+* `HTTPMethod`
+* `AnonymousURL`
+
+'Opener' directives are Option directives which have a corresponding 'closer' Option directive. See [L4002](#l4002]) for more information.
+
+---------
+
+### L1006 - An Option 'closer' directive is out of order
+
+* `Option Cookie`
+* `Option NoHideEZproxy`
+* `Option HttpsHyphens`
+* `Option NoMetaEZproxyRewriting`
+* `Option NoProxyFTP`
+* `Option NoUTF16`
+* `Option NoX-Forwarded-For`
+
+directives are only allowed to follow other 'closer' directives and:
+
+* `URL`
+* `Host`
+* `HostJavaScript`
+* `Domain`
+* `DomainJavaScript`
+* `Replace`
+* `AnonymousURL`
+* `NeverProxy`
+
+'Closer' directives are Option directives which have a corresponding 'opener' Option directive. See [L4002](#l4002]) for more information.
+
+---------
+
+### L1008 - `ProxyHostnameEdit` directive is out of order
+
+The `ProxyHostnameEdit` directive is only allowed to follow the following directives:
+
+* `Group`
+* `HTTPMethod`
+* `AnonymousURL`
+* `ProxyHostnameEdit`
+* `Option DomainCookieOnly`
+* `Option NoCookie`
+* `Option CookiePassThrough`
+* `Option HideEZproxy`
+* `Option NoHttpsHyphens`
+* `Option MetaEZproxyRewriting`
+* `Option ProxyFTP`
+* `Option UTF16`
+* `Option X-Forwarded-For`
+
+---------
+
+### L1009 - `ProxyHostnameEdit` domains should be placed in deepest-to-shallowest order
 
 This check is enabled with the `-phe=true` option.
 
@@ -203,43 +215,19 @@ but a.short.domain.ca is four components deep.
 
 ---------
 
-### L1010
-
-#### `URL` directive is before `Title` directive
+### L1010 - `URL` directive is before `Title` directive
 
 The `URL` directive should always come after the `Title` is a given stanza.
 
----------
-
-### L1011
-
-#### `Option Cookie` directive
-
-The `Option Cookie` directive, when used at the end of a stanza to prevent other cookie handling options from impacting other stanzas, is only allowed to follow the following directives:
-
-* `URL`
-* `Host`
-* `HostJavaScript`
-* `Domain`
-* `DomainJavaScript`
-* `Replace`
-* `AnonymousURL`
-* `Option NoX-Forwarded-For`
-
-
 ## L2 - Duplication Issues
 
-### L2001
-
-#### Duplicate `Title` directive in stanza
+### L2001 - Duplicate `Title` directive in stanza
 
 More than one `Title` directive present in a stanza.
 
 ---------
 
-### L2002
-
-#### Origin already seen
+### L2002 - Origin already seen
 
 EZproxy [only reads origins and does not read paths](https://help.oclc.org/Library_Management/EZproxy/Configure_resources/Groups).
 The origin is the combination of the scheme (http or https), the host (google.com, help.oclc.org), and the port.
@@ -248,162 +236,150 @@ The linter will report if you've already used an origin, so that you can ensure 
 
 ---------
 
-### L2003
-
-#### Duplicate `URL` directive in stanza
+### L2003 - Duplicate `URL` directive in stanza
 
 More than one `URL` directive present in a stanza.
 
 ---------
 
-### L2004
-
-#### `Title` value already seen
+### L2004 - `Title` value already seen
 
 The linter tracks stanza `Title` values and reports when a value has been seen more than
 once.
 
-
 ## L3 - Malformation Issues
 
-### L3001
-
-#### `ProxyHostnameEdit` directive must have two values
+### L3001 - `ProxyHostnameEdit` directive must have both a find and replace qualifier
 
 The `ProxyHostnameEdit` directive requires two qualifiers.
 See [OCLC Documentation](https://help.oclc.org/Library_Management/EZproxy/Configure_resources/ProxyHostnameEdit) for more details.
 
 ---------
 
-### L3002
+### L3002 - Find part of `ProxyHostnameEdit` directive should end with a `$`
 
-#### Find part of `ProxyHostnameEdit` directive should end with a `$`
+This check is enabled with the `-phe=true` option.
 
-This check is enabled with the `-phe=true` option. The first qualifier to `ProxyHostnameEdit`, *find*, is a regular expression and should end in a dollar sign (`$`) to match the end of the string.
-
----------
-
-### L3003
-
-#### Replace part of `ProxyHostnameEdit` directive is malformed
-
-This check is enabled with the `-phe=true` option. To make redirects from HTTP to HTTPS links more reliable, this check ensures that the *find* and *replace* qualifiers correspond with each other: *replace* should just be *find*, but with the trailing `$` removed and the periods replaced with hypens.
+The first qualifier to `ProxyHostnameEdit`, *find*, is a regular expression and should end in a dollar sign (`$`) to match the end of the string.
 
 ---------
 
-### L3004
+### L3003 - Replace part of `ProxyHostnameEdit` directive is malformed
 
-#### `Domain` and `DomainJavaScript` directives should only specify domains
+This check is enabled with the `-phe=true` option.
+
+To make redirects from HTTP to HTTPS links more reliable, this check ensures that the *find* and *replace* qualifiers correspond with each other: *replace* should just be *find*, but with the trailing `$` removed and the periods replaced with hypens. For example, `home.heinonline.org$` corresponds with `home-heinonline-org`.
+
+---------
+
+### L3004 -  `Domain` and `DomainJavaScript` directives should only specify domains
 
 The `Domain` and `DomainJavaScript` directives should only specify domains.
 No URLs or path components should be used.
 
 ---------
 
-### L3005
-
-#### Unable to parse `URL`
+### L3005 - Unable to parse `URL`
 
 The URL part of this directive could not be parsed, check to see if it is malformed.
 
 ---------
 
-### L3006
-
-#### `URL` does not start with `http` or `https`
+### L3006 - `URL` does not start with `http` or `https`
 
 The scheme/protocol of the URL should be specified, and it should either be `http` or `https`.
 
 ---------
 
-### L3007
+### L3007 -  `URL` is not using HTTPS scheme
 
-#### `URL` is not using HTTPS scheme
+This check is enabled with the `-https=true` option.
 
-This check is enabled with the `-https=true` option. The URL should use the `https` scheme/protocol.
+The URL should use the `https` scheme/protocol.
 
 ---------
 
-### L3008
-
-#### `Option` directive not in the form `Option OPTIONNAME`
+### L3008 - `Option` directive not in the form `Option OPTIONNAME`
 
 The `Option` directive needs a second part. You can see the list of options in the [OCLC documentation](https://help.oclc.org/Library_Management/EZproxy/Configure_resources).
 
 ---------
 
-### L3009
-
-#### `URL` directive is not in the right format
+### L3009 - `URL` directive is not in the right format
 
 The `URL` directive must be in the [URL (version 1)](https://help.oclc.org/Library_Management/EZproxy/Configure_resources/URL_version_1), [URL (version 2)](https://help.oclc.org/Library_Management/EZproxy/Configure_resources/URL_version_2), or [URL (version 3)](https://help.oclc.org/Library_Management/EZproxy/Configure_resources/URL_version_3) format. Ensure line is not malformed.
 
 
 ## L4 - Missing Directive Issues
 
-### L4001
-
-#### Missing `AnonymousURL -*` at end of stanza
+### L4001 - Missing `AnonymousURL -*` at end of stanza
 
 Stanzas which use a AnonymousURL directive should include a `AnonymousURL -*` line at the end of the stanza so that other stanzas in the config file are not impacted.
 
 ---------
 
-### L4002
+### L4002 - Missing Option at end of stanza
 
-#### Missing `Option Cookie` at end of stanza
+Stanzas which use options like `Option X-Forwarded-For` or `Option DomainCookieOnly` need to have a corresponding option like `Option NoX-Forwarded-For` or `Option Cookie` at the end of the stanza to ensure these options do not impact other stanzas.
 
-Stanzas which use a Option DomainCookieOnly or Option CookiePassthrough directive should include a `Option Cookie` line at the end of the stanza so that other stanzas in the config file are not impacted.
+Here's the table of 'opener' and 'closer' Option directives:
+
+|Opener|Closer|
+|---|---|
+| Option DomainCookieOnly | Option Cookie |
+| Option NoCookie | Option Cookie |
+| Option CookiePassThrough | Option Cookie |
+| Option HideEZproxy | Option NoHideEZproxy |
+| Option NoHttpsHyphens | Option HttpsHyphens |
+| Option MetaEZproxyRewriting | Option NoMetaEZproxyRewriting |
+| Option ProxyFTP | Option NoProxyFTP |
+| Option UTF16 | Option NoUTF16 |
+| Option X-Forwarded-For | OptionNoXForwardedFor |
 
 ---------
 
-### L4003
-
-#### Stanza has `Title` but no `URL`
+### L4003 - Stanza has `Title` but no `URL`
 
 Stanzas should have both a Title and a URL directive.
 
 ---------
 
-### L4004
-
-#### `Find` directive must be immediately proceeded with a `Replace` directive
+### L4004 - `Find` directive must be immediately proceeded with a `Replace` directive
 
 From the [OCLC documentation](https://help.oclc.org/Library_Management/EZproxy/Configure_resources/Find_Replace):
 
 "These directives always appear paired together, with Find appearing directly before its corresponding Replace."
 
-
 ## L5 - Styling Issues
 
-### L5001
+### L5001 - Directive uses the wrong case.
 
-#### Directive uses the wrong case.
+This check is enabled with the `-case=true` option.
 
-This check is enabled with the `-case=true` option. The directive was found, but it does not use the normal case. For example, TITLE instead of Title, or HTTPheader instead of HTTPHeader.
+The directive was found, but it does not use the normal case. For example, TITLE instead of Title, or HTTPheader instead of HTTPHeader.
 
-### L5002
+---------
 
-#### Line ends in a space or tab character.
+### L5002 - Line ends in a space or tab character.
 
-This check is enabled with the `-whitespace=true` option. Trailing whitespace characters space or tab were found on this line.
+This check is enabled with the `-whitespace=true` option.
+
+Trailing whitespace characters space or tab were found on this line.
 
 ---------
 
 
 ## L9 - Other Issues
 
-### L9001
-
-#### Unknown directive
+### L9001 - Unknown directive
 
 An unknown directive was encountered. This can be caused by a typo in the directive. You can check the list of possible directives in the [OCLC documentation](https://help.oclc.org/Library_Management/EZproxy/Configure_resources).
 
 ---------
 
-### L9002
+### L9002 - Source title doesn't match
 
-#### Source title doesn't match
+This check is disabled with the `-source=false` option.
 
 The linter has a built-in way to check the OCLC website for updates to some database stanzas.
 If a comment is seen which matches the pattern `# Source - https://help.oclc.org/Library_Management/EZproxy/EZproxy_database_stanzas/...`,
@@ -427,8 +403,8 @@ Title Docuseek2 (updated 20191015)
 
 Because the `Title` directives do not match, the tool will report that you might want to update the stanza from the source.
 
-### L9003
+---------
 
-#### Error processing Source line
+### L9003 - Error processing Source line
 
 There was some problem processing the Source line. The URL might be malformed, or there was an HTTP request issue.

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -155,7 +155,7 @@ func (l *Linter) ProcessFile(filePath string) (warningCount int, err error) {
 		if l.FollowIncludeFile && l.State.Previous == IncludeFile {
 			splitLine := strings.Split(line, " ")
 			if len(splitLine) < 2 {
-				return warningCount, fmt.Errorf("unable to find IncludeFile path on line \"%v\"", line)
+				return warningCount, fmt.Errorf("unable to find IncludeFile path on line %q", line)
 			}
 			includeFilePath := splitLine[1]
 			help := ""
@@ -165,19 +165,19 @@ func (l *Linter) ProcessFile(filePath string) (warningCount int, err error) {
 			if !filepath.IsAbs(includeFilePath) {
 				if l.IncludeFileDirectory != "" {
 					includeFilePath = filepath.Join(l.IncludeFileDirectory, includeFilePath)
-					help = fmt.Sprintf("The \"-includefile-directory\" option was used, joined \"%v\" with \"%v\"", l.IncludeFileDirectory, includeFilePath)
+					help = fmt.Sprintf("The \"-includefile-directory\" option was used, joined %q with %q", l.IncludeFileDirectory, includeFilePath)
 				} else {
 					filePathDir := filepath.Dir(filePath)
 					includeFilePath = filepath.Join(filePathDir, includeFilePath)
-					help += fmt.Sprintf("This IncludeFile directive is in a config file at this path: \"%v\"\n", filePath)
-					help += fmt.Sprintf("            The IncludeFile directive resolves to this path: \"%v\"", includeFilePath)
+					help += fmt.Sprintf("This IncludeFile directive is in a config file at this path: %q\n", filePath)
+					help += fmt.Sprintf("            The IncludeFile directive resolves to this path: %q", includeFilePath)
 				}
 			}
 
 			includeFileWarningCount, err := l.ProcessFile(includeFilePath)
 			if err != nil {
 				// Help people debug errors with IncludeFile parent directories.
-				log.Printf("Error encountered when processing line \"%v\".\n", line)
+				log.Printf("Error encountered when processing line %q.\n", line)
 				log.Println(help)
 				if l.IncludeFileDirectory == "" {
 					log.Println("You might want to try the \"-includefile-directory\" option.")
@@ -221,16 +221,16 @@ func (l *Linter) ProcessLineAt(line, at string) (m []string) {
 	// Is the line empty, or an empty comment?
 	if line == "" || line == "#" {
 		if l.State.Title != "" && l.State.URL == "" {
-			m = append(m, fmt.Sprintf("Stanza \"%v\" has Title but no URL (L4003)", l.State.Title))
+			m = append(m, fmt.Sprintf("Stanza %q has Title but no URL (L4003)", l.State.Title))
 		}
 		if l.State.AnonymousURLNeedsClosing {
-			m = append(m, fmt.Sprintf("Stanza \"%v\" has AnonymousURL but doesn't have a corresponding \"AnonymousURL -*\" "+
+			m = append(m, fmt.Sprintf("Stanza %q has AnonymousURL but doesn't have a corresponding \"AnonymousURL -*\" "+
 				"line at the end of the stanza (L4001)", l.State.Title))
 		}
 		if len(l.State.OpenOptions) != 0 {
 			for _, option := range l.State.OpenOptions {
-				m = append(m, fmt.Sprintf("Stanza \"%v\" has \"%v\" but doesn't have a "+
-					"corresponding \"%v\" line at the end of the stanza (L4002)", l.State.Title, option, optionPairs[option]))
+				m = append(m, fmt.Sprintf("Stanza %q has %q but doesn't have a "+
+					"corresponding %q line at the end of the stanza (L4002)", l.State.Title, option, optionPairs[option]))
 			}
 		}
 		// Reset the stanza state.
@@ -284,11 +284,11 @@ func (l *Linter) ProcessLineAt(line, at string) (m []string) {
 	if !ok {
 		directive, ok = LowercaseLabelToDirective[strings.ToLower(label)]
 		if !ok {
-			m = append(m, fmt.Sprintf("Unknown directive \"%v\" (L9001)", label))
+			m = append(m, fmt.Sprintf("Unknown directive %q (L9001)", label))
 			return m
 		}
 		if l.DirectiveCase {
-			m = append(m, fmt.Sprintf("\"%v\" directive does not have the right letter casing. It should be replaced by \"%v\" (L5001)", label, directive))
+			m = append(m, fmt.Sprintf("%q directive does not have the right letter casing. It should be replaced by %q (L5001)", label, directive))
 		}
 	}
 	l.State.Current = directive
@@ -336,7 +336,7 @@ func (l *Linter) ProcessOptionOpener(line string) (m []string) {
 	}
 	allowedPreviousDirectives = append(allowedPreviousDirectives, OpenerOptions()...)
 	if !slices.Contains(allowedPreviousDirectives, l.State.Previous) {
-		m = append(m, fmt.Sprintf("\"%v\" directive is out of order, previous directive: \"%v\" (L1005)", l.State.Current, l.State.Previous))
+		m = append(m, fmt.Sprintf("%q directive is out of order, previous directive: %q (L1005)", l.State.Current, l.State.Previous))
 	}
 	l.State.OpenOptions = append(l.State.OpenOptions, l.State.Current)
 	return m
@@ -357,7 +357,7 @@ func (l *Linter) ProcessOptionCloser(line string) (m []string) {
 	}
 	allowedPreviousDirectives = append(allowedPreviousDirectives, CloserOptions()...)
 	if !slices.Contains(allowedPreviousDirectives, l.State.Previous) {
-		m = append(m, fmt.Sprintf("\"%v\" directive is out of order, previous directive: \"%v\" (L1006)", l.State.Current, l.State.Previous))
+		m = append(m, fmt.Sprintf("%q directive is out of order, previous directive: %q (L1006)", l.State.Current, l.State.Previous))
 	}
 	l.State.OpenOptions = slices.DeleteFunc(l.State.OpenOptions, func(d Directive) bool {
 		return optionPairs[d] == l.State.Current
@@ -378,7 +378,7 @@ func (l *Linter) ProcessProxyHostnameEdit(line string) (m []string) {
 	}
 	allowedPreviousDirectives = append(allowedPreviousDirectives, OpenerOptions()...)
 	if !slices.Contains(allowedPreviousDirectives, l.State.Previous) {
-		m = append(m, fmt.Sprintf("\"ProxyHostnameEdit\" directive is out of order, previous directive: \"%v\" (L1008)", l.State.Previous))
+		m = append(m, fmt.Sprintf("\"ProxyHostnameEdit\" directive is out of order, previous directive: %q (L1008)", l.State.Previous))
 	}
 	// Does the ProxyHostnameEdit line have both a find and replace?
 	findReplacePair := strings.Split(TrimDirective(line, l.State.Current), " ")
@@ -421,7 +421,7 @@ func (l *Linter) ProcessAnonymousURL(line string) (m []string) {
 		}
 		allowedPreviousDirectives = append(allowedPreviousDirectives, CloserOptions()...)
 		if !slices.Contains(allowedPreviousDirectives, l.State.Previous) {
-			m = append(m, fmt.Sprintf("\"AnonymousURL -*\" directive is out of order, previous directive: \"%v\" (L1003)", l.State.Previous))
+			m = append(m, fmt.Sprintf("\"AnonymousURL -*\" directive is out of order, previous directive: %q (L1003)", l.State.Previous))
 		}
 		l.State.AnonymousURLNeedsClosing = false
 	} else {
@@ -434,7 +434,7 @@ func (l *Linter) ProcessAnonymousURL(line string) (m []string) {
 		}
 		allowedPreviousDirectives = append(allowedPreviousDirectives, OpenerOptions()...)
 		if !slices.Contains(allowedPreviousDirectives, l.State.Previous) {
-			m = append(m, fmt.Sprintf("\"AnonymousURL\" directive is out of order, previous directive: \"%v\" (L1004)", l.State.Previous))
+			m = append(m, fmt.Sprintf("\"AnonymousURL\" directive is out of order, previous directive: %q (L1004)", l.State.Previous))
 		}
 		l.State.AnonymousURLNeedsClosing = true
 	}
@@ -458,11 +458,11 @@ func (l *Linter) ProcessTitle(line, at string) (m []string) {
 	}
 	allowedPreviousDirectives = append(allowedPreviousDirectives, OpenerOptions()...)
 	if !slices.Contains(allowedPreviousDirectives, l.State.Previous) {
-		m = append(m, fmt.Sprintf("\"Title\" directive is out of order, previous directive: \"%v\" (L1001)", l.State.Previous))
+		m = append(m, fmt.Sprintf("\"Title\" directive is out of order, previous directive: %q (L1001)", l.State.Previous))
 	}
 	// If the previous AnonymousURL directive was `AnonymousURL -*`, that's a problem.
 	if l.State.Previous == AnonymousURL && !l.State.AnonymousURLNeedsClosing {
-		m = append(m, fmt.Sprintf("\"Title\" directive is out of order, previous directive: \"%v\" (L1001)", l.State.Previous))
+		m = append(m, fmt.Sprintf("\"Title\" directive is out of order, previous directive: %q (L1001)", l.State.Previous))
 	}
 
 	if l.State.Title != "" {
@@ -471,7 +471,7 @@ func (l *Linter) ProcessTitle(line, at string) (m []string) {
 	l.State.Title = TrimDirective(line, l.State.Current)
 	titleSeenAt, titleSeen := l.PreviousTitles[l.State.Title]
 	if titleSeen {
-		m = append(m, fmt.Sprintf("\"Title\" directive value already seen at \"%v\" (L2004)", titleSeenAt))
+		m = append(m, fmt.Sprintf("\"Title\" directive value already seen at %q (L2004)", titleSeenAt))
 	} else {
 		l.PreviousTitles[l.State.Title] = at
 	}
@@ -506,7 +506,7 @@ func (l *Linter) ProcessHostAndHostJavaScript(line, at string) (m []string) {
 	origin := fmt.Sprintf("%v://%v", parsedURL.Scheme, parsedURL.Host)
 	originSeenAt, originSeen := l.PreviousOrigins[origin]
 	if originSeen {
-		m = append(m, fmt.Sprintf("Origin already seen at \"%v\" (L2002)", originSeenAt))
+		m = append(m, fmt.Sprintf("Origin already seen at %q (L2002)", originSeenAt))
 	} else {
 		l.PreviousOrigins[origin] = at
 	}
@@ -545,7 +545,7 @@ func (l *Linter) ProcessURL(line string) (m []string) {
 		Title,
 	}
 	if !slices.Contains(allowedPreviousDirectives, l.State.Previous) {
-		m = append(m, fmt.Sprintf("\"URL\" directive is out of order, previous directive: \"%v\" (L1002)", l.State.Previous))
+		m = append(m, fmt.Sprintf("\"URL\" directive is out of order, previous directive: %q (L1002)", l.State.Previous))
 	}
 
 	if l.State.Title == "" {

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -80,7 +80,7 @@ func TestTrailingSpaceOrTabCheck(t *testing.T) {
 	for _, tt := range tests {
 		problem := TrailingSpaceOrTabCheck(tt.line)
 		if problem != tt.expected {
-			t.Fatalf("TrailingSpaceOrTabCheck() fails on \"%v\", wanted %v, got %v.\n", tt.line, tt.expected, problem)
+			t.Fatalf("TrailingSpaceOrTabCheck() fails on %q, wanted %v, got %v.\n", tt.line, tt.expected, problem)
 		}
 	}
 }
@@ -156,7 +156,7 @@ func TestFindURLFromLine(t *testing.T) {
 	for _, tt := range tests {
 		urlQualifier := FindURLFromLine(tt.line)
 		if urlQualifier != tt.expected {
-			t.Fatalf("FindURLFromLine() fails on \"%v\", wanted \"%v\", got \"%v\".\n", tt.line, tt.expected, urlQualifier)
+			t.Fatalf("FindURLFromLine() fails on %q, wanted %q, got %q.\n", tt.line, tt.expected, urlQualifier)
 		}
 	}
 }

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -273,5 +273,4 @@ func TestUnclosedOptionDirectives(t *testing.T) {
 			t.Fatalf("incorrect messages %v instead of %v", messages, tt.expected)
 		}
 	}
-
 }

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -107,7 +107,7 @@ func TestFindReplacePair(t *testing.T) {
 	linter := Linter{State: State{
 		Previous: Find,
 	}}
-	expected := []string{"Find directive must be immediately proceeded with a Replace directive (L4004)"}
+	expected := []string{"\"Find\" directive must be immediately proceeded with a \"Replace\" directive (L4004)"}
 	messages := linter.ProcessLineAt("NeverProxy google.com", "test:1")
 	if !reflect.DeepEqual(messages, expected) {
 		t.Fatalf("incorrect messages %v instead of %v", messages, expected)
@@ -159,4 +159,119 @@ func TestFindURLFromLine(t *testing.T) {
 			t.Fatalf("FindURLFromLine() fails on \"%v\", wanted \"%v\", got \"%v\".\n", tt.line, tt.expected, urlQualifier)
 		}
 	}
+}
+
+func TestUnclosedOptionDirectives(t *testing.T) {
+	var tests = []struct {
+		linter   Linter
+		expected []string
+	}{
+		{
+			Linter{
+				State: State{
+					Title:       "DomainCookieOnlyMissing",
+					URL:         "https://test.com",
+					OpenOptions: []Directive{OptionDomainCookieOnly},
+				},
+			},
+			[]string{"Stanza \"DomainCookieOnlyMissing\" has \"Option DomainCookieOnly\" but doesn't have a " +
+				"corresponding \"Option Cookie\" line at the end of the stanza (L4002)"},
+		},
+		{
+			Linter{
+				State: State{
+					Title:       "OptionNoCookie",
+					URL:         "https://test.com",
+					OpenOptions: []Directive{OptionNoCookie},
+				},
+			},
+			[]string{"Stanza \"OptionNoCookie\" has \"Option NoCookie\" but doesn't have a " +
+				"corresponding \"Option Cookie\" line at the end of the stanza (L4002)"},
+		},
+		{
+			Linter{
+				State: State{
+					Title:       "OptionCookiePassThrough",
+					URL:         "https://test.com",
+					OpenOptions: []Directive{OptionCookiePassThrough},
+				},
+			},
+			[]string{"Stanza \"OptionCookiePassThrough\" has \"Option CookiePassThrough\" but doesn't have a " +
+				"corresponding \"Option Cookie\" line at the end of the stanza (L4002)"},
+		},
+		{
+			Linter{
+				State: State{
+					Title:       "OptionHideEZproxy",
+					URL:         "https://test.com",
+					OpenOptions: []Directive{OptionHideEZproxy},
+				},
+			},
+			[]string{"Stanza \"OptionHideEZproxy\" has \"Option HideEZproxy\" but doesn't have a " +
+				"corresponding \"Option NoHideEZproxy\" line at the end of the stanza (L4002)"},
+		},
+		{
+			Linter{
+				State: State{
+					Title:       "OptionNoHttpsHyphens",
+					URL:         "https://test.com",
+					OpenOptions: []Directive{OptionNoHttpsHyphens},
+				},
+			},
+			[]string{"Stanza \"OptionNoHttpsHyphens\" has \"Option NoHttpsHyphens\" but doesn't have a " +
+				"corresponding \"Option HttpsHyphens\" line at the end of the stanza (L4002)"},
+		},
+		{
+			Linter{
+				State: State{
+					Title:       "OptionMetaEZproxyRewriting",
+					URL:         "https://test.com",
+					OpenOptions: []Directive{OptionMetaEZproxyRewriting},
+				},
+			},
+			[]string{"Stanza \"OptionMetaEZproxyRewriting\" has \"Option MetaEZproxyRewriting\" but doesn't have a " +
+				"corresponding \"Option NoMetaEZproxyRewriting\" line at the end of the stanza (L4002)"},
+		},
+		{
+			Linter{
+				State: State{
+					Title:       "OptionProxyFTP",
+					URL:         "https://test.com",
+					OpenOptions: []Directive{OptionProxyFTP},
+				},
+			},
+			[]string{"Stanza \"OptionProxyFTP\" has \"Option ProxyFTP\" but doesn't have a " +
+				"corresponding \"Option NoProxyFTP\" line at the end of the stanza (L4002)"},
+		},
+		{
+			Linter{
+				State: State{
+					Title:       "OptionUTF16",
+					URL:         "https://test.com",
+					OpenOptions: []Directive{OptionUTF16},
+				},
+			},
+			[]string{"Stanza \"OptionUTF16\" has \"Option UTF16\" but doesn't have a " +
+				"corresponding \"Option NoUTF16\" line at the end of the stanza (L4002)"},
+		},
+		{
+			Linter{
+				State: State{
+					Title:       "OptionXForwardedFor",
+					URL:         "https://test.com",
+					OpenOptions: []Directive{OptionXForwardedFor},
+				},
+			},
+			[]string{"Stanza \"OptionXForwardedFor\" has \"Option X-Forwarded-For\" but doesn't have a " +
+				"corresponding \"Option NoX-Forwarded-For\" line at the end of the stanza (L4002)"},
+		},
+	}
+
+	for _, tt := range tests {
+		messages := tt.linter.ProcessLineAt("", "test:1")
+		if !reflect.DeepEqual(messages, tt.expected) {
+			t.Fatalf("incorrect messages %v instead of %v", messages, tt.expected)
+		}
+	}
+
 }

--- a/testdata/invalid/unclosed_optionhideezproxy.txt
+++ b/testdata/invalid/unclosed_optionhideezproxy.txt
@@ -1,0 +1,14 @@
+Option HideEZproxy
+T ImageQuest
+U http://quest.eb.com
+HTTPMethod PUT
+HJ search.eb.com
+HJ m.search.eb.com
+DJ eb.com
+HJ www.britannica.com
+DJ britannica.com
+Find Config.individualLoginDomain = "individual.eb.com"
+Replace Config.individualLoginDomain = "^pindividual.eb.com^"
+Find loginHost += _getProxyAppendix();
+Replace loginHost = loginHost;
+NeverProxy webstats.eb.com

--- a/testdata/invalid/unclosed_optionuft16.txt
+++ b/testdata/invalid/unclosed_optionuft16.txt
@@ -1,0 +1,4 @@
+Option UTF16
+Title Siku Quanshu
+URL http://skqs.yourlib.org
+DJ skqs.yourlib.org

--- a/testdata/invalid/unclosed_optionxforwardedfor.txt
+++ b/testdata/invalid/unclosed_optionxforwardedfor.txt
@@ -1,0 +1,8 @@
+Option X-Forwarded-For
+HTTPHeader x-cas-*
+HTTPMethod DELETE
+Title CAS MethodsNow
+URL https://www.methodsnow.com
+D methodsnow.com
+DJ cas.org
+H sso.cas.org

--- a/testdata/valid/ImageQuest.txt
+++ b/testdata/valid/ImageQuest.txt
@@ -1,0 +1,15 @@
+Option HideEZproxy
+T ImageQuest
+U http://quest.eb.com
+HTTPMethod PUT
+HJ search.eb.com
+HJ m.search.eb.com
+DJ eb.com
+HJ www.britannica.com
+DJ britannica.com
+Find Config.individualLoginDomain = "individual.eb.com"
+Replace Config.individualLoginDomain = "^pindividual.eb.com^"
+Find loginHost += _getProxyAppendix();
+Replace loginHost = loginHost;
+NeverProxy webstats.eb.com
+Option NoHideEZproxy

--- a/testdata/valid/MethodsNow.txt
+++ b/testdata/valid/MethodsNow.txt
@@ -1,0 +1,9 @@
+Option X-Forwarded-For
+HTTPHeader x-cas-*
+HTTPMethod DELETE
+Title CAS MethodsNow
+URL https://www.methodsnow.com
+D methodsnow.com
+DJ cas.org
+H sso.cas.org
+Option NoX-Forwarded-For

--- a/testdata/valid/Siku_Quanshu.txt
+++ b/testdata/valid/Siku_Quanshu.txt
@@ -1,0 +1,5 @@
+Option UTF16
+Title Siku Quanshu
+URL http://skqs.yourlib.org
+DJ skqs.yourlib.org
+Option NoUTF16


### PR DESCRIPTION
* The Options directives which have a corresponding 'closing' Option directive are now handled as a group, instead of individually.
* In the output, the names are directives are (hopefully) all surrounded by double quotes. This makes output messages for all directives consistent.
* The CHECKS markdown headers have been simplified.

This PR closes #39 #38 #37 #35 #32, and improves our documentation on directive ordering. 