### PR TITLE
Properly handle trimming the label from the line

### DIFF
--- a/testdata/valid/Chronicle_of_Higher_Education_mixed_case.txt
+++ b/testdata/valid/Chronicle_of_Higher_Education_mixed_case.txt
@@ -1,0 +1,21 @@
+AnonymousURL +https://sh.chronicle.com/*
+AnonymousUrl +https://data.chronicle.com/*
+AnonymousURL +https://data.shorthand.com/*
+tItLe The Chronicle of Higher Education (updated 20190726)
+Url https://www.chronicle.com
+HJ chronicle.com
+HJ data.chronicle.com
+HJ data.shorthand.com
+HJ https://data.shorthand.com
+HJ projects.chronicle.com
+HJ www.chronicle.com
+Hj https://chronicle.com
+HJ https://data.chronicle.com
+HJ https://projects.chronicle.com
+HJ https://sh.chronicle.com
+DJ data.shorthand.com
+DJ www.chronicle.com
+fInD data-url="//data.shorthand.com
+replAce data-url="https://data.shorthand.com
+NeverProxy hive.chronicle.com
+AnonymousUrl -*


### PR DESCRIPTION
If you work backwards from the current directive, you won't trim labels that only match in a case-insensitive way.

Instead, store the label that was actually found, and trim that from the line instead.

This fixes issue #45.