### PR TITLE
Handle nested IncludeFile directives, better help documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ $ tar xzvf ezproxy-config-lint_Linux_x86_64.tar.gz
 $ cd ezproxy-config-lint_Linux_x86_64
 $ ./ezproxy-config-lint -help
 ezproxy-config-lint: Lint config files for EZproxy
+Usage:
+  ezproxy-config-lint [options] <file>...
+Options:
   -annotate
         Print all lines, not just lines that create warnings.
   -case
@@ -57,7 +60,7 @@ ezproxy-config-lint: Lint config files for EZproxy
   -https
         Report on URL directives which do not use the HTTPS scheme.
   -includefile-directory string
-        The directory from which the IncludeFile paths will be resolved. By default, IncludeFile paths are resolved from the config file's directory, unless they are absolute paths.
+        The directory from which the IncludeFile paths will be resolved. By default, IncludeFile paths are resolved from the parent directory of each of the file arguments, unless they are absolute paths.
   -phe
         Perform additional checks on ProxyHostnameEdit directives.
   -source

--- a/testdata/valid/IncludeFileNestedOne.txt
+++ b/testdata/valid/IncludeFileNestedOne.txt
@@ -1,0 +1,1 @@
+IncludeFile includefile_subdirectory/IncludeFileNestedTwo.txt

--- a/testdata/valid/includefile_subdirectory/IncludeFileNestedThree.txt
+++ b/testdata/valid/includefile_subdirectory/IncludeFileNestedThree.txt
@@ -1,0 +1,2 @@
+Title A title
+URL https://url.com

--- a/testdata/valid/includefile_subdirectory/IncludeFileNestedTwo.txt
+++ b/testdata/valid/includefile_subdirectory/IncludeFileNestedTwo.txt
@@ -1,0 +1,1 @@
+IncludeFile includefile_subdirectory/IncludeFileNestedThree.txt

--- a/testdata_test.go
+++ b/testdata_test.go
@@ -29,8 +29,8 @@ func TestInvalid(t *testing.T) {
 		t.Logf("> invalid: %s\n", filename)
 
 		l := NewLinter()
-		ret, _ := l.ProcessFile(f)
-		if ret == 0 {
+		warningCount, err := l.ProcessFile(f)
+		if err == nil && warningCount == 0 {
 			t.Errorf("Unexpected success on invalid file: %s\n", filename)
 		}
 	}
@@ -47,8 +47,8 @@ func TestValid(t *testing.T) {
 		t.Logf("> valid: %s\n", filename)
 
 		l := NewLinter()
-		ret, _ := l.ProcessFile(f)
-		if ret != 0 {
+		warningCount, err := l.ProcessFile(f)
+		if err != nil || warningCount != 0 {
 			t.Errorf("Unexpected error on valid file: %s\n", filename)
 		}
 	}


### PR DESCRIPTION
A very similar PR to #56, in that it sets the parent directory for nested IncludeFile directives during the first call to `ProcessFile()`. However, this PR reuses the linter's IncludeFileDirectory, hides the debug output behind `-verbose`, and handles the case where files with different parent directories are passed on the CLI as arguments. 