### PR TITLE
Improvements on processing origins in URLs.

### DIFF
--- a/testdata/invalid/duplicate_url_origin.txt
+++ b/testdata/invalid/duplicate_url_origin.txt
@@ -1,0 +1,11 @@
+Option UTF16
+Title Siku Quanshu
+URL http://skqs.yourlib.org
+DJ skqs.yourlib.org
+Option NoUTF16
+
+Option UTF16
+Title Siku Quanshu Two
+URL http://skqs.yourlib.org
+DJ skqs.yourlib.org
+Option NoUTF16

--- a/testdata/invalid/origin_in_another_stanza_hj.txt
+++ b/testdata/invalid/origin_in_another_stanza_hj.txt
@@ -1,0 +1,8 @@
+Title Siku Quanshu
+URL http://skqs.yourlib.org
+HJ http://skqs2.yourlib.org
+DJ skqs.yourlib.org
+
+Title Siku Quanshu Two
+URL http://skqs2.yourlib.org
+DJ skqs.yourlib.org

--- a/testdata/invalid/origin_in_another_stanza_url.txt
+++ b/testdata/invalid/origin_in_another_stanza_url.txt
@@ -1,0 +1,8 @@
+Title Siku Quanshu
+URL http://skqs.yourlib.org
+DJ skqs.yourlib.org
+
+Title Siku Quanshu Two
+URL http://skqs2.yourlib.org
+HJ http://skqs.yourlib.org
+DJ skqs.yourlib.org


### PR DESCRIPTION
- URL origins are now checked against previously seen origins.
- At the end of a stanza, the stanza's URL origin is added to the list of previously seen origins.

This fixes #62.