### PR TITLE
Update URL origin detection

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ func main() {
 	directiveCase := flag.Bool("case", false, "Report on directives having the wrong case.")
 	https := flag.Bool("https", false, "Report on URL directives which do not use the HTTPS scheme.")
 	source := flag.Bool("source", true, "Use source comments to check against OCLC stanzas.")
+	pedantic := flag.Bool("pedantic", false, "Enable pedantic checks.")
 	whitespace := flag.Bool("whitespace", false, "Report on trailing space or tab characters.")
 	followIncludeFile := flag.Bool("follow-includefile", true, "Also process files referenced by IncludeFile directives.")
 	includeFileDirectory := flag.String("includefile-directory", "", "The directory from which the IncludeFile paths will be resolved. "+
@@ -58,6 +59,7 @@ func main() {
 		DirectiveCase:        *directiveCase,
 		HTTPS:                *https,
 		Source:               *source,
+		Pedantic:             *pedantic,
 		Whitespace:           *whitespace,
 		FollowIncludeFile:    *followIncludeFile,
 		IncludeFileDirectory: *includeFileDirectory,

--- a/testdata/invalid/duplicate_url_origin.txt
+++ b/testdata/invalid/duplicate_url_origin.txt
@@ -1,0 +1,11 @@
+Option UTF16
+Title Siku Quanshu
+URL http://skqs.yourlib.org
+DJ skqs.yourlib.org
+Option NoUTF16
+
+Option UTF16
+Title Siku Quanshu Two
+URL http://skqs.yourlib.org
+DJ skqs.yourlib.org
+Option NoUTF16

--- a/testdata/invalid/origin_in_another_stanza_hj.txt
+++ b/testdata/invalid/origin_in_another_stanza_hj.txt
@@ -1,0 +1,8 @@
+Title Siku Quanshu
+URL http://skqs.yourlib.org
+HJ http://skqs2.yourlib.org
+DJ skqs.yourlib.org
+
+Title Siku Quanshu Two
+URL http://skqs2.yourlib.org
+DJ skqs.yourlib.org

--- a/testdata/invalid/origin_in_another_stanza_url.txt
+++ b/testdata/invalid/origin_in_another_stanza_url.txt
@@ -1,0 +1,8 @@
+Title Siku Quanshu
+URL http://skqs.yourlib.org
+DJ skqs.yourlib.org
+
+Title Siku Quanshu Two
+URL http://skqs2.yourlib.org
+HJ http://skqs.yourlib.org
+DJ skqs.yourlib.org

--- a/testdata/invalid/pedantic/ProxyHostNameEdit.txt
+++ b/testdata/invalid/pedantic/ProxyHostNameEdit.txt
@@ -1,0 +1,40 @@
+ProxyHostnameEdit m.cshprotocols.cshlp.org$ m-cshprotocols-cshlp-org
+ProxyHostnameEdit cshperspectives.cshlp.org$ cshperspectives-cshlp-org
+ProxyHostnameEdit cshprotocols.cshlp.org$ cshprotocols-cshlp-org
+ProxyHostnameEdit genesdev.cshlp.org$ genesdev-cshlp-org
+ProxyHostnameEdit genome.cshlp.org$ genome-cshlp-org
+ProxyHostnameEdit learnmem.cshlp.org$ learnmem-cshlp-org
+ProxyHostnameEdit rnajournal.cshlp.org$ rnajournal-cshlp-org
+ProxyHostnameEdit symposium.cshlp.org$ symposium-cshlp-org
+ProxyHostnameEdit www.cshlp.org$ www-cshlp-org
+ProxyHostnameEdit www.cshlpress.org$ www-cshlpress-org
+ProxyHostnameEdit www.genesdev.org$ www-genesdev-org
+ProxyHostnameEdit www.rnajournal.org$ www-rnajournal-org
+ProxyHostnameEdit rnajournal.org$ rnajournal-org
+T Cold Spring Harbor Laboratory Press (OCLC IncludeFile updated 20230519)
+U https://www.cshlpress.org
+HJ cshperspectives.cshlp.org
+HJ cshprotocols.cshlp.org
+HJ genesdev.cshlp.org
+HJ genome.cshlp.org
+HJ https://cshperspectives.cshlp.org
+HJ https://genesdev.cshlp.org
+HJ https://genome.cshlp.org
+HJ https://rnajournal.cshlp.org
+HJ https://rnajournal.org
+HJ https://www.cshlpress.org
+HJ https://www.rnajournal.org
+HJ https://learnmem.cshlp.org
+HJ learnmem.cshlp.org
+HJ rnajournal.cshlp.org
+HJ rnajournal.org
+HJ m.cshprotocols.cshlp.org
+HJ symposium.cshlp.org
+HJ www.cshlp.org
+HJ www.cshlpress.org
+HJ www.genesdev.org
+HJ www.rnajournal.org
+DJ cshlp.org
+DJ cshlpress.org
+DJ genesdev.org
+DJ rnajournal.org

--- a/testdata/invalid/pedantic/ScienceDirect.txt
+++ b/testdata/invalid/pedantic/ScienceDirect.txt
@@ -1,0 +1,70 @@
+# Elsevier ScienceDirect
+Cookie BROWSER_SUPPORTS_COOKIES=1;domain=.sciencedirect.com
+AnonymousURL +https://rss.sciencedirect.com/
+Title ScienceDirect (Updated 20230125)
+URL https://www.sciencedirect.com
+HJ https://www.sciencedirect.com
+HJ https://sciencedirect.com
+HJ http://www.sciencedirect.com
+HJ sciencedirect.com
+HJ linkinghub.elsevier.com
+HJ https://linkinghub.elsevier.com
+HJ www.elsevier.com
+HJ admintool.elsevier.com
+HJ https://admintool.elsevier.com
+HJ online.tableau.com
+HJ help-admintool.elsevier.com
+HJ tableau-admintool.elsevier.com
+DJ sciencedirect.com
+DJ www.elsevier.com
+DJ *.els-cdn.com
+Find value="http://
+Replace value="http://^A
+Find %22%3A%22https%3A%2F%2Fsciverse-shindig.elsevier.com%2F
+Replace %22%3A%22https%3A%2F%2F^ssciverse-shindig.elsevier.com^%2F
+Find gsUrl%22%3A%22https%3A%2F%2Fwww.sciencedirect.com%2F
+Replace gsUrl%22%3A%22https%3A%2F%2F^swww.sciencedirect.com^%2F
+Find pdfurl%3D%22https%3A%2F%2Fwww.sciencedirect.com%2F
+Replace pdfurl%3D%22https%3A%2F%2F^swww.sciencedirect.com^%2F
+Find pdfurl="//www.sciencedirect.com/
+Replace pdfurl="//^swww.sciencedirect.com^/
+Find redirect_uri=https://
+Replace redirect_uri=https://^A
+Find "null/
+Replace "//^swww.sciencedirect.com^/
+AnonymousURL -*
+
+#Elsevier Scopus
+ProxyHostnameEdit www.scopus.com$ www-scopus-com
+HTTPMethod OPTIONS
+AnonymousURL +http://syndic8.scopus.com/*
+AnonymousURL +https://components.scopus.com/*
+AnonymousURL -OPTIONS +https://components.scopus.com/*
+Title Scopus (updated 20230911)
+MimeFilter text/uri-list .* javascript
+MimeFilter application/json .* javascript
+URL https://www.scopus.com/home.url
+HJ https://scopus.com
+HJ https://www.elsevier.com
+HJ https://www.scopus.com
+HJ https://www2.scopus.com
+HJ scopus.com
+HJ www.scopus.com
+HJ www2.scopus.com
+DJ www.elsevier.com
+DJ scopus.com
+Find gsUrl%22%3A%22https%3A%2F%2Fwww.scopus.com%2F
+Replace gsUrl%22%3A%22https%3A%2F%2F^pwww.scopus.com^%2F
+Find ["APP_DOMAIN"] = "www.scopus.com";
+Replace ["APP_DOMAIN"] = "^swww.scopus.com^";
+Find redirect_uri=https://
+Replace redirect_uri=https://^A
+AnonymousURL -*
+
+Title -hide Elsevier Identity
+URL https://id.elsevier.com
+HJ https://id.elsevier.com
+HJ id.elsevier.com
+DJ id.elsevier.com
+Find redirect_uri=https://
+Replace redirect_uri=https://^A

--- a/testdata_test.go
+++ b/testdata_test.go
@@ -19,16 +19,37 @@ func NewLinter() *linter.Linter {
 }
 
 func TestInvalid(t *testing.T) {
-	dirContent, err := filepath.Glob("testdata/invalid/*.txt")
+	root := "testdata/invalid/"
+	dirContent, err := filepath.Glob(root + "*.txt")
 	if err != nil {
 		panic(err)
 	}
 
 	for _, f := range dirContent {
-		filename := strings.TrimPrefix(f, "testdata/invalid/")
+		filename := strings.TrimPrefix(f, root)
 		t.Logf("> invalid: %s\n", filename)
 
 		l := NewLinter()
+		warningCount, err := l.ProcessFile(f)
+		if err == nil && warningCount == 0 {
+			t.Errorf("Unexpected success on invalid file: %s\n", filename)
+		}
+	}
+}
+
+func TestInvalidPedantic(t *testing.T) {
+	root := "testdata/invalid/pedantic/"
+	dirContent, err := filepath.Glob(root + "*.txt")
+	if err != nil {
+		panic(err)
+	}
+
+	for _, f := range dirContent {
+		filename := strings.TrimPrefix(f, root)
+		t.Logf("> invalid: %s\n", filename)
+
+		l := NewLinter()
+		l.Pedantic = true
 		warningCount, err := l.ProcessFile(f)
 		if err == nil && warningCount == 0 {
 			t.Errorf("Unexpected success on invalid file: %s\n", filename)


### PR DESCRIPTION
Submitting this draft to compare it with #66.  We were working concurrently on the same issue.  I refactored my draft by incorporating the good ideas from #66 while adding a pedantic mode flag for reporting duplicates within the same stanza.

The number of L2002 results against the [Kent State repo](https://github.com/kent-state-university-libraries/oclc-ezproxy-database-stanzas):

- main: 3809
- PR 66: 3974 (+165 over main)
- Pedantic: 4586 (+612 over PR 66)

Still needs polish, but I wanted to share it to help us decide what parts are worth keeping.